### PR TITLE
feat: add 'a' key to start agent on existing worktree

### DIFF
--- a/src/commands/shortcuts.rs
+++ b/src/commands/shortcuts.rs
@@ -35,6 +35,7 @@ pub enum Shortcut {
 
     // Agent / Worktree
     DispatchAgent,
+    StartAgent,
     OpenTmux,
     OpenAnyTmux,
     ViewLogs,
@@ -83,6 +84,7 @@ impl Shortcut {
             Self::ReopenIssue,
             Self::AssignUser,
             Self::DispatchAgent,
+            Self::StartAgent,
             Self::OpenTmux,
             Self::OpenAnyTmux,
             Self::ViewLogs,
@@ -127,6 +129,7 @@ impl Shortcut {
             Self::ReopenIssue => "X",
             Self::AssignUser => "a",
             Self::DispatchAgent => "d",
+            Self::StartAgent => "a",
             Self::OpenTmux => "t",
             Self::OpenAnyTmux => "T",
             Self::ViewLogs => "l",
@@ -171,6 +174,7 @@ impl Shortcut {
             Self::ReopenIssue => "Reopen issue",
             Self::AssignUser => "Assign user",
             Self::DispatchAgent => "Dispatch agent",
+            Self::StartAgent => "Start agent",
             Self::OpenTmux => "Open tmux session",
             Self::OpenAnyTmux => "Open any tmux session",
             Self::ViewLogs => "View agent logs",
@@ -195,6 +199,7 @@ impl Shortcut {
             Self::CreateIssueAI => "ai",
             Self::CreateIssueDirect => "new",
             Self::DispatchAgent => "dispatch",
+            Self::StartAgent => "agent",
             Self::OpenIDE => "ide",
             Self::CreatePR => "pr",
             Self::OpenTmux => "tmux",
@@ -245,6 +250,7 @@ impl Shortcut {
             | Self::AssignUser => CommandCategory::Issues,
 
             Self::DispatchAgent
+            | Self::StartAgent
             | Self::ViewLogs
             | Self::KillAgent
             | Self::OpenIDE
@@ -341,6 +347,7 @@ impl Shortcut {
                 CommandContext::WorktreeList,
             ],
             Self::CreateWorktree => &[CommandContext::WorktreeList],
+            Self::StartAgent => &[CommandContext::WorktreeList],
 
             // Browser open
             Self::OpenInBrowser => &[

--- a/src/tui_events/worktree.rs
+++ b/src/tui_events/worktree.rs
@@ -178,6 +178,30 @@ pub fn handle_worktree_list_key(
                 }
             }
         }
+        KeyCode::Char('a') => {
+            // Start agent on selected worktree
+            if let Some(wt) = worktrees.get(*selected) {
+                // Check if tmux session is already running
+                let session_name = if let Some(issue_num) = wt.issue_number {
+                    crate::agents::tmux_session_name(&wt.project, issue_num)
+                } else {
+                    wt.name.clone()
+                };
+
+                if crate::agents::is_tmux_session_running(&session_name) {
+                    browser.status_message =
+                        Some("Tmux session already running. Open it with 't'.".to_string());
+                } else {
+                    // Extract branch name from worktree name
+                    let branch_name = wt.name.clone();
+                    browser.view = TuiView::WorktreeAgentInstructions {
+                        worktree_path: wt.path.clone(),
+                        branch_name,
+                        input: String::new(),
+                    };
+                }
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
## Summary
- Add `a` shortcut in worktree list to start an agent on an existing worktree
- Shows instructions popup before launching the agent in tmux

Closes #32